### PR TITLE
Optimize verses_html

### DIFF
--- a/db/migrations/2018-10-05-022234_verses_and_fts/down.sql
+++ b/db/migrations/2018-10-05-022234_verses_and_fts/down.sql
@@ -1,3 +1,3 @@
 DROP TABLE verses;
-DROP VIEW verses_html;
+DROP TABLE verses_html;
 DROP TABLE verses_fts;

--- a/db/migrations/2018-10-05-022234_verses_and_fts/up.sql
+++ b/db/migrations/2018-10-05-022234_verses_and_fts/up.sql
@@ -22,7 +22,16 @@ INSERT INTO verses
     FROM words
     GROUP BY book, chapter, verse;
 
-CREATE VIEW verses_html AS
+CREATE TABLE verses_html (
+    id INTEGER PRIMARY KEY NOT NULL,
+    book INTEGER NOT NULL REFERENCES books(id),
+    chapter INTEGER NOT NULL,
+    verse INTEGER NOT NULL,
+    words TEXT NOT NULL
+);
+CREATE INDEX verses_html_book_chapter_idx ON verses_html(book, chapter);
+
+INSERT INTO verses_html
     SELECT CAST(book || substr('000' || chapter, -3, 3) || substr('000' || verse, -3, 3) AS INTEGER) AS id,
         book,
         chapter,

--- a/db/src/schema/auto.rs
+++ b/db/src/schema/auto.rs
@@ -26,6 +26,16 @@ table! {
 }
 
 table! {
+    verses_html (id) {
+        id -> Integer,
+        book -> Integer,
+        chapter -> Integer,
+        verse -> Integer,
+        words -> Text,
+    }
+}
+
+table! {
     words (id) {
         id -> Integer,
         book -> Integer,
@@ -43,10 +53,12 @@ table! {
 
 joinable!(book_abbreviations -> books (book_id));
 joinable!(verses -> books (book));
+joinable!(verses_html -> books (book));
 
 allow_tables_to_appear_in_same_query!(
     book_abbreviations,
     books,
     verses,
+    verses_html,
     words,
 );

--- a/db/src/schema/mod.rs
+++ b/db/src/schema/mod.rs
@@ -13,16 +13,6 @@ table! {
     }
 }
 
-table! {
-    verses_html (id) {
-        id -> Integer,
-        book -> Integer,
-        chapter -> Integer,
-        verse -> Integer,
-        words -> Text,
-    }
-}
-
 allow_tables_to_appear_in_same_query!(books, verses_fts);
 
 mod auto;


### PR DESCRIPTION
Having the HTML version as a view into the words is a dog on a single
core machine, while it's fine with eight cores. This sacrifices 5MB of
table space to materialize that view into a table.