### PR TITLE
Improve service-worker caching

### DIFF
--- a/web/dist/js/sw.js
+++ b/web/dist/js/sw.js
@@ -1,14 +1,34 @@
-// version: 2 (improve logos)
+const CACHE_NAME = "biblers-cache-v3";
 
+// Use cache before fetching from the network.
 self.addEventListener("fetch", (e) => {
-    e.respondWith(
-        caches.match(e.request).then(resp => resp || fetch(e.request)),
-    );
+    // Search API requests are not locally cached.
+    if (e.request.url.indexOf("/api/search") > -1) {
+        e.respondWith(
+            caches.match(e.request).then(resp => resp || fetch(e.request)),
+        );
+
+    // Standard pages are cached.
+    } else {
+        e.respondWith(
+            caches.match(e.request).then(initialResp => {
+                console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
+                return initialResp || fetch(e.request).then(resp => {
+                    return caches.open(CACHE_NAME).then(cache => {
+                        console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
+                        cache.put(e.request, resp.clone());
+                        return resp;
+                    })
+                })
+            }),
+        )
+    }
 });
 
+// Install static files.
 self.addEventListener("install", (e) => {
     e.waitUntil(
-        caches.open("biblers-cache").then(cache => cache.addAll([
+        caches.open(CACHE_NAME).then(cache => cache.addAll([
             "/",
             "/static/manifest.json",
             "/static/css/style.css",
@@ -21,5 +41,18 @@ self.addEventListener("install", (e) => {
             "/static/js/autocomplete.min.js",
             "/static/js/main.js",
         ])),
+    );
+});
+
+// Clear the old caches.
+self.addEventListener("activate", (e) => {
+    e.waitUntil(
+        caches.keys().then((keyList) => {
+            return Promise.all(keyList.map((k) => {
+                if (CACHE_NAME.indexOf(k) === -1) {
+                    return caches.delete(k);
+                }
+            }));
+        }),
     );
 });

--- a/web/dist/js/sw.js
+++ b/web/dist/js/sw.js
@@ -4,23 +4,19 @@ const CACHE_NAME = "biblers-cache-v3";
 self.addEventListener("fetch", (e) => {
     // Search API requests are not locally cached.
     if (e.request.url.indexOf("/api/search") > -1) {
-        e.respondWith(
-            caches.match(e.request).then(resp => resp || fetch(e.request)),
-        );
+        e.respondWith(fetch(e.request));
 
     // Standard pages are cached.
     } else {
         e.respondWith(
-            caches.match(e.request).then(initialResp => {
-                console.log(`[Service Worker] Fetching resource: ${e.request.url}`);
-                return initialResp || fetch(e.request).then(resp => {
-                    return caches.open(CACHE_NAME).then(cache => {
-                        console.log(`[Service Worker] Caching new resource: ${e.request.url}`);
+            caches.match(e.request).then(initialResp =>
+                initialResp || fetch(e.request).then(resp =>
+                    caches.open(CACHE_NAME).then(cache => {
                         cache.put(e.request, resp.clone());
                         return resp;
                     })
-                })
-            }),
+                )
+            ),
         )
     }
 });
@@ -47,12 +43,12 @@ self.addEventListener("install", (e) => {
 // Clear the old caches.
 self.addEventListener("activate", (e) => {
     e.waitUntil(
-        caches.keys().then((keyList) => {
-            return Promise.all(keyList.map((k) => {
+        caches.keys().then((keyList) =>
+            Promise.all(keyList.map((k) => {
                 if (CACHE_NAME.indexOf(k) === -1) {
                     return caches.delete(k);
                 }
-            }));
-        }),
+            }))
+        ),
     );
 });


### PR DESCRIPTION
This commit makes the PWA service worker caching more aggressive, while
also adding proper cleanup for old cache data. Instead of only caching
static resources (JS, CSS, images, etc.), we should also be caching page
requests. This is done with each request attempting to look in the cache
first, and if not found, fetch from the network (then cache). The
rational can be found here:
https://developer.mozilla.org/en-US/docs/Web/Apps/Progressive/Offline_Service_workers

This closes #18.