### PR TITLE
Preserve aria-label on input

### DIFF
--- a/web/dist/js/main.js
+++ b/web/dist/js/main.js
@@ -24,6 +24,7 @@
     ]).on("autocomplete:selected", function (e, suggestion) {
         document.location.href = suggestion.link.url;
     });
+    document.getElementById("q").setAttribute("aria-label", "Search the Bible");
 
     document.onkeypress = function (e) {
         if (e.ctrlKey || e.altKey || e.metaKey) {


### PR DESCRIPTION
autocomplete.js has an option for `ariaLabel` in its configuration, but
it doesn't currently work correctly. Thus, this commit sets the value
manually after the autocomplete input is initiated.

This fixes #21.