### PR TITLE
Add json-ld

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cookies or third-party analytic services involved in Bible.rs.
 
 ## Ideas for the Future
 - Add more metadata (book author, year written, etc.).
-- Add Schema.org metadata to each page.
+- Improve Schema.org metadata.
 - Add languages other than English.
 - When and if SQLite is ever a bottleneck, switch to a client-server database.
 - Make the searching "smart."

--- a/web/src/json_ld.rs
+++ b/web/src/json_ld.rs
@@ -1,0 +1,298 @@
+use serde::ser::{Serialize, Serializer};
+use serde_derive::*;
+use serde_json;
+
+use db::models::{Book, Reference};
+
+use crate::controllers::{AllBooksLinks, BookLinks, Link, VersesLinks, NAME};
+
+const CONTEXT: &str = "https://schema.org";
+const CREATOR_FIRST_NAME: &str = "Dustin";
+const CREATOR_LAST_NAME: &str = "Speckhals";
+const CREATOR_URL: &str = "https://speckhals.com";
+const LANGUAGE: &str = "en-us";
+const KEYWORDS: &str = "bible,kjv";
+const VERSION: &str = "King James Version";
+
+#[derive(Clone, Debug)]
+pub enum JsonLd {
+    BreadcrumbList(BreadcrumbListJsonLd),
+    About(Box<AboutJsonLd>),
+    AllBooks(AllBooksJsonLd),
+    Book(BookJsonLd),
+    Reference(ReferenceJsonLd),
+}
+
+impl Serialize for JsonLd {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(
+            &match self {
+                JsonLd::BreadcrumbList(s) => serde_json::to_string_pretty(&s),
+                JsonLd::About(s) => serde_json::to_string_pretty(&s),
+                JsonLd::AllBooks(s) => serde_json::to_string_pretty(&s),
+                JsonLd::Book(s) => serde_json::to_string_pretty(&s),
+                JsonLd::Reference(s) => serde_json::to_string_pretty(&s),
+            }
+            .unwrap(),
+        )
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+enum Kind {
+    BookSeries,
+    Book,
+    BreadcrumbList,
+    Chapter,
+    ListItem,
+    Person,
+    Thing,
+    Website,
+}
+
+/********** json-ld Building Blocks **********/
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BreadcrumbListJsonLd {
+    #[serde(rename = "@context")]
+    context: String,
+
+    item_list_element: Vec<ListItemJsonLd>,
+
+    #[serde(rename = "@type")]
+    kind: Kind,
+}
+
+impl BreadcrumbListJsonLd {
+    pub fn new(list_items: Vec<ListItemJsonLd>) -> Self {
+        Self {
+            context: CONTEXT.to_string(),
+            item_list_element: list_items,
+            kind: Kind::BreadcrumbList,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ListItemJsonLd {
+    item: String,
+
+    #[serde(rename = "@type")]
+    kind: Kind,
+
+    name: String,
+    position: i32,
+}
+
+impl ListItemJsonLd {
+    pub fn new(link: &Link, position: i32) -> Self {
+        Self {
+            item: format!(url_format!(), link.url),
+            kind: Kind::ListItem,
+            name: link.label.to_owned(),
+            position,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+struct PartJsonLd {
+    #[serde(rename = "@id")]
+    id: String,
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct PersonJsonLd {
+    family_name: String,
+    given_name: String,
+
+    #[serde(flatten)]
+    thing: ThingJsonLd,
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ThingJsonLd {
+    #[serde(rename = "@context")]
+    context: String,
+
+    #[serde(rename = "@id")]
+    id: String,
+
+    #[serde(rename = "@type")]
+    kind: Kind,
+
+    name: String,
+    url: String,
+}
+
+impl Default for ThingJsonLd {
+    fn default() -> Self {
+        Self {
+            context: CONTEXT.to_string(),
+            id: format!(url_format!(), ""),
+            kind: Kind::Thing,
+            name: "Default".to_string(),
+            url: format!(url_format!(), ""),
+        }
+    }
+}
+
+/********** Page Implementations **********/
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AboutJsonLd {
+    creator: PersonJsonLd,
+    keywords: String,
+
+    #[serde(flatten)]
+    thing: ThingJsonLd,
+}
+
+impl AboutJsonLd {
+    pub fn new() -> Self {
+        let person_thing = ThingJsonLd {
+            id: CREATOR_URL.to_string(),
+            kind: Kind::Person,
+            name: format!("{} {}", CREATOR_FIRST_NAME, CREATOR_LAST_NAME),
+            url: CREATOR_URL.to_string(),
+            ..ThingJsonLd::default()
+        };
+        let creator = PersonJsonLd {
+            thing: person_thing,
+            family_name: CREATOR_LAST_NAME.to_string(),
+            given_name: CREATOR_FIRST_NAME.to_string(),
+        };
+        let thing = ThingJsonLd {
+            id: format!(url_format!(), "/about"),
+            kind: Kind::Website,
+            name: NAME.to_string(),
+            url: format!(url_format!(), "/about"),
+            ..ThingJsonLd::default()
+        };
+
+        Self {
+            creator,
+            keywords: KEYWORDS.to_string(),
+            thing,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AllBooksJsonLd {
+    has_part: Vec<PartJsonLd>,
+    in_language: String,
+
+    #[serde(flatten)]
+    thing: ThingJsonLd,
+
+    version: String,
+}
+
+impl AllBooksJsonLd {
+    pub fn new(links: &AllBooksLinks) -> Self {
+        let has_part = links
+            .books
+            .iter()
+            .map(|b| PartJsonLd {
+                id: format!(url_format!(), b.url),
+            })
+            .collect();
+        let thing = ThingJsonLd {
+            id: format!(url_format!(), ""),
+            kind: Kind::BookSeries,
+            name: NAME.to_string(),
+            url: format!(url_format!(), ""),
+            ..ThingJsonLd::default()
+        };
+
+        Self {
+            has_part,
+            in_language: LANGUAGE.to_string(),
+            thing,
+            version: VERSION.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BookJsonLd {
+    has_part: Vec<PartJsonLd>,
+    in_language: String,
+    is_part_of: PartJsonLd,
+    position: i32,
+
+    #[serde(flatten)]
+    thing: ThingJsonLd,
+}
+
+impl BookJsonLd {
+    pub fn new(book: &Book, links: &BookLinks) -> Self {
+        let has_part = links
+            .chapters
+            .iter()
+            .map(|c| PartJsonLd {
+                id: format!(url_format!(), c),
+            })
+            .collect();
+        let is_part_of = PartJsonLd {
+            id: format!(url_format!(), links.books.url),
+        };
+        let thing = ThingJsonLd {
+            id: format!(url_format!(), links.current.url),
+            kind: Kind::Book,
+            name: book.name.to_owned(),
+            url: format!(url_format!(), links.current.url),
+            ..ThingJsonLd::default()
+        };
+
+        Self {
+            has_part,
+            in_language: LANGUAGE.to_string(),
+            is_part_of,
+            position: book.id,
+            thing,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ReferenceJsonLd {
+    is_part_of: PartJsonLd,
+    position: i32,
+
+    #[serde(flatten)]
+    thing: ThingJsonLd,
+}
+
+impl ReferenceJsonLd {
+    pub fn new(reference: &Reference, links: &VersesLinks) -> Self {
+        let thing = ThingJsonLd {
+            id: format!(url_format!(), links.current.url),
+            kind: Kind::Chapter,
+            name: reference.to_string(),
+            url: format!(url_format!(), links.current.url),
+            ..ThingJsonLd::default()
+        };
+        let is_part_of = PartJsonLd {
+            id: format!(url_format!(), links.book.url),
+        };
+
+        Self {
+            is_part_of,
+            position: reference.chapter,
+            thing,
+        }
+    }
+}

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all)]
+
 use std::env;
 use std::error::Error;
 
@@ -71,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .resource("about", |r| r.get().with(view::about))
         .resource("/", |r| {
             r.name("bible");
-            r.get().with(view::all_books)
+            r.get().f(view::all_books)
         })
         .resource("search", |r| r.get().f(view::search))
         .resource("{book}", |r| {
@@ -99,3 +101,4 @@ fn main() -> Result<(), Box<dyn Error>> {
 mod actors;
 mod controllers;
 mod error;
+mod json_ld;

--- a/web/templates/about.hbs
+++ b/web/templates/about.hbs
@@ -56,7 +56,7 @@
         <h2>Ideas for the Future</h2>
         <ul>
             <li>Add more metadata (book author, year written, etc.).</li>
-            <li>Add Schema.org metadata to each page.</li>
+            <li>Improve Schema.org metadata.</li>
             <li>Add languages other than English.</li>
             <li>When and if SQLite is ever a bottleneck, switch to a client-server database.</li>
             <li>Make the searching "smart."</li>

--- a/web/templates/all-books.hbs
+++ b/web/templates/all-books.hbs
@@ -5,9 +5,9 @@
     </nav>
     <nav>
         <ol>
-            {{~ #each books as |book|}}
+            {{~ #each links.books as |book|}}
             <li>
-                <a href="/{{name}}">{{name}}</a>
+                <a href="{{url}}">{{label}}</a>
             </li>
             {{~ /each}}
         </ol>

--- a/web/templates/base.hbs
+++ b/web/templates/base.hbs
@@ -27,6 +27,11 @@
     <meta name="apple-mobile-web-app-title" content="Bible.rs">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="#444444">
+    {{~ #each meta.json_ld as |json_ld|}}
+    <script type="application/ld+json">
+    {{{json_ld}}}
+    </script>
+    {{~ /each}}
 </head>
 
 <body>


### PR DESCRIPTION
This commit adds json-ld generation to all pages except the search
results and error pages. This is a first draft, so I imagine there is
plenty of room for improvement to the metadata.

This closes #22.