### PR TITLE
Add nav buttons to bottom of pages

### DIFF
--- a/web/dist/js/sw.js
+++ b/web/dist/js/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "biblers-cache-v3";
+const CACHE_NAME = "biblers-cache-v4";
 
 // Use cache before fetching from the network.
 self.addEventListener("fetch", (e) => {

--- a/web/styles/_global.scss
+++ b/web/styles/_global.scss
@@ -55,19 +55,17 @@ ol {
     margin: 2rem auto;
 }
 
-nav {
-    &.top-nav, &.bottom-nav {
-        text-align: center;
-    }
+nav.top-nav {
+    text-align: center;
 }
 
-.heading {
+.heading, .footing {
     .previous {
         display: inline-block;
         width: 15%;
         text-align: left;
     }
-    h1 {
+    h1, .book {
         display: inline-block;
         width: 67%;
         text-align: center;

--- a/web/styles/pages/_chapter.scss
+++ b/web/styles/pages/_chapter.scss
@@ -10,7 +10,7 @@
                 margin-top: 2rem;
             }
 
-            &:last-child {
+            &:nth-last-child(2) {
                 margin-bottom: 2rem;
             }
 

--- a/web/templates/book.hbs
+++ b/web/templates/book.hbs
@@ -5,23 +5,23 @@
             <img src="/static/img/bible.rs.svg" alt="BIBLE.RS" height="100" width="100" class="logo">
         </a>
     </nav>
-    <div class="heading">
-        <nav class="previous">
+    <nav class="heading">
+        <div class="previous">
             {{~ #if links.previous}}
             <a href="{{links.previous.url}}" title="{{links.previous.label}}">
                 <img src="/static/img/arrow-back.svg" alt="Back Arrow" height="28" width="28">
             </a>
             {{~ /if}}
-        </nav>
+        </div>
         <h1>{{book.name}}</h1>
-        <nav class="next">
+        <div class="next">
             {{~ #if links.next}}
             <a href="{{links.next.url}}" title="{{links.next.label}}">
                 <img src="/static/img/arrow-forward.svg" alt="Forward Arrow" height="28" width="28">
             </a>
             {{~ /if}}
-        </nav>
-    </div>
+        </div>
+    </nav>
     <nav>
         <ol>
             {{~ #each chapters as |c|}}

--- a/web/templates/chapter.hbs
+++ b/web/templates/chapter.hbs
@@ -6,23 +6,25 @@
         </a>
     </nav>
     <article>
-        <div class="heading">
-            <nav class="previous">
+
+        <nav class="heading">
+            <div class="previous">
                 {{~ #if links.previous}}
                 <a href="{{links.previous.url}}" title="{{links.previous.label}}">
                     <img src="/static/img/arrow-back.svg" alt="Back Arrow" height="28" width="28">
                 </a>
                 {{~ /if}}
-            </nav>
+            </div>
             <h1>{{reference_string}}</h1>
-            <nav class="next">
+            <div class="next">
                 {{~ #if links.next}}
                 <a href="{{links.next.url}}" title="{{links.next.label}}">
                     <img src="/static/img/arrow-forward.svg" alt="Forward Arrow" height="28" width="28">
                 </a>
                 {{~ /if}}
-            </nav>
-        </div>
+            </div>
+        </nav>
+
         {{~ #each verses as |v|}}
         <p id="v{{v.verse}}">
             <a href="{{@root.data.links.current.url}}#v{{v.verse}}">
@@ -31,19 +33,37 @@
             {{{v.words}}}
         </p>
         {{~ /each}}
+
+        <nav class="footing">
+            <div class="previous">
+                {{~ #if links.previous}}
+                <a href="{{links.previous.url}}" title="{{links.previous.label}}">
+                    <img src="/static/img/arrow-back.svg" alt="Back Arrow" height="28" width="28">
+                </a>
+                {{~ /if}}
+            </div>
+            <div class="book">
+                {{~ #if reference.verses}}
+                <a href="{{links.chapter.url}}" title="{{links.chapter.label}}">
+                    <img src="/static/img/unfold-more.svg" alt="View all of {{links.chapter.label}}" height="28" width="28">
+                    View Full Chapter&nbsp;
+                </a>
+                {{~ /if}}
+                <a href="{{links.book.url}}" title="{{links.book.label}}">
+                    <img src="/static/img/book.svg" alt="Go to {{links.book.label}}" height="28" width="28">
+                    {{links.book.label}}
+                </a>
+            </div>
+            <div class="next">
+                {{~ #if links.next}}
+                <a href="{{links.next.url}}" title="{{links.next.label}}">
+                    <img src="/static/img/arrow-forward.svg" alt="Forward Arrow" height="28" width="28">
+                </a>
+                {{~ /if}}
+            </div>
+        </nav>
+
     </article>
-    <nav class="bottom-nav">
-        {{~ #if reference.verses}}
-        <a href="{{links.chapter.url}}" title="{{links.chapter.label}}">
-            <img src="/static/img/unfold-more.svg" alt="View all of {{links.chapter.label}}" height="28" width="28">
-            View Full Chapter&nbsp;
-        </a>
-        {{~ /if}}
-        <a href="{{links.book.url}}" title="{{links.book.label}}">
-            <img src="/static/img/book.svg" alt="Go to {{links.book.label}}" height="28" width="28">
-            {{links.book.label}}
-        </a>
-    </nav>
 </div>
 {{~ /inline}}
 {{~> base ~}}


### PR DESCRIPTION
There were already previous and next navigation links on the start of
the page, but it is convenient to also have them at the end. This commit
adds the links, and also makes structural changes to the related HTML
surrounding it for the sake of simplification.