### PR TITLE
Fix Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
 
 env:
-  - DATABASE_URL=/tmp/biblers.db
+  - DATABASE_URL=/tmp/biblers.db CAPTURE_ERRORS=false
 
 addons:
   apt:


### PR DESCRIPTION
libssl is required for linking at runtime for the Bible.rs web binary.
Also, since Buster is the default Debian distribution for `rust:latest`
now, just use `rust:latest` for compiling again.