### PR TITLE
Make sentry DSN a variable rather than hardcoded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rust:
   - beta
   - nightly
 
-env:
-  - DATABASE_URL=/tmp/biblers.db CAPTURE_ERRORS=false
-
 addons:
   apt:
     packages:

--- a/web/src/controllers/view.rs
+++ b/web/src/controllers/view.rs
@@ -94,9 +94,10 @@ where
                         let verses_data = VersesData::new(result, data_reference, &req);
 
                         if verses_data.verses.is_empty() {
-                            Err(Error::InvalidReference {
+                            return Err(Error::InvalidReference {
                                 reference: raw_reference,
-                            })?;
+                            }
+                            .into());
                         }
 
                         let body = TemplateData::new(

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> io::Result<()> {
 
     // Get env configuration
     let sentry_dsn = env::var("SENTRY_DSN").ok();
-    let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = env::var("DATABASE_URL").unwrap_or_else(|_| "/tmp/biblers.db".to_string());
 
     // Set up sentry
     let capture_errors = sentry_dsn.is_some();

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -37,14 +37,12 @@ fn main() -> io::Result<()> {
     env_logger::init();
 
     // Get env configuration
-    let capture_errors = env::var("CAPTURE_ERRORS")
-        .unwrap_or_else(|_| "true".to_string())
-        .parse::<bool>()
-        .expect("Invalid value for CAPTURE_ERRORS. Must be 'true' or 'false.'");
+    let sentry_dsn = env::var("SENTRY_DSN").ok();
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
     // Set up sentry
-    let _guard = sentry::init("https://b2dc20aad7f64ae9a9c5e8a77e947d9c@sentry.io/1768339");
+    let capture_errors = sentry_dsn.is_some();
+    let _guard = sentry::init(sentry_dsn);
     if capture_errors {
         sentry::integrations::panic::register_panic_handler();
     }


### PR DESCRIPTION
Though it was convenient to have the Sentry (issue alerting) DSN
hardcoded into `web::main`, it was too easy for alerts to be sent
unintentionally (e.g. if the repo was forked and tested by another).
This commit makes the DSN an environment variable, which is defaulted to
`None`; thus disabling alerting if the var isn't set.