### PR TITLE
Add swipe navigation

### DIFF
--- a/db/src/models/reference.rs
+++ b/db/src/models/reference.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 use std::str::FromStr;
 
 use lazy_static::lazy_static;
@@ -14,7 +14,7 @@ use crate::DbError;
 pub struct Reference {
     pub book: String,
     pub chapter: i32,
-    pub verses: Option<Range<i32>>,
+    pub verses: Option<RangeInclusive<i32>>,
 }
 
 impl fmt::Display for Reference {
@@ -30,10 +30,17 @@ impl fmt::Display for Reference {
                 chapter,
                 verses: Some(verses),
             } => {
-                if verses.start == verses.end {
-                    write!(f, "{} {}:{}", book, chapter, verses.start)
+                if verses.start() == verses.end() {
+                    write!(f, "{} {}:{}", book, chapter, verses.start())
                 } else {
-                    write!(f, "{} {}:{}-{}", book, chapter, verses.start, verses.end)
+                    write!(
+                        f,
+                        "{} {}:{}-{}",
+                        book,
+                        chapter,
+                        verses.start(),
+                        verses.end()
+                    )
                 }
             }
         }
@@ -74,7 +81,7 @@ impl FromStr for Reference {
                         Ok(Reference {
                             book,
                             chapter: parse_num_match(chapter)?,
-                            verses: Some(verse..verse),
+                            verses: Some(verse..=verse),
                         })
                     }
                     // Chapter with more than one verse
@@ -84,7 +91,7 @@ impl FromStr for Reference {
                         Ok(Reference {
                             book,
                             chapter: parse_num_match(chapter)?,
-                            verses: Some(verse_start..verse_end),
+                            verses: Some(verse_start..=verse_end),
                         })
                     }
                     _ => Err(invalid_reference(s)),
@@ -121,11 +128,11 @@ mod tests {
             ("Song of Solomon 1", "Song of Solomon", 1, None),
             ("Exodus 20", "Exodus", 20, None),
             ("1cor 4", "1cor", 4, None),
-            ("John 1:1", "John", 1, Some(1..1)),
-            ("jhn.1.1", "jhn", 1, Some(1..1)),
-            ("I Timothy 3:16", "I Timothy", 3, Some(16..16)),
-            ("1 Timothy 3:16-18", "1 Timothy", 3, Some(16..18)),
-            ("1tim 3.16", "1tim", 3, Some(16..16)),
+            ("John 1:1", "John", 1, Some(1..=1)),
+            ("jhn.1.1", "jhn", 1, Some(1..=1)),
+            ("I Timothy 3:16", "I Timothy", 3, Some(16..=16)),
+            ("1 Timothy 3:16-18", "1 Timothy", 3, Some(16..=18)),
+            ("1tim 3.16", "1tim", 3, Some(16..=16)),
         ]
         .iter()
         .for_each(|(raw, book, chapter, verses)| {
@@ -148,10 +155,10 @@ mod tests {
             ("3 John 1", "3 John", 1, None),
             ("Exodus 20", "Exodus", 20, None),
             ("1 Cor 4", "1 Cor", 4, None),
-            ("John 1:1", "John", 1, Some(1..1)),
-            ("I Timothy 3:16", "I Timothy", 3, Some(16..16)),
-            ("1 Timothy 3:16-18", "1 Timothy", 3, Some(16..18)),
-            ("1Tim 3:16", "1Tim", 3, Some(16..16)),
+            ("John 1:1", "John", 1, Some(1..=1)),
+            ("I Timothy 3:16", "I Timothy", 3, Some(16..=16)),
+            ("1 Timothy 3:16-18", "1 Timothy", 3, Some(16..=18)),
+            ("1Tim 3:16", "1Tim", 3, Some(16..=16)),
         ]
         .iter()
         .for_each(|(expected, book, chapter, verses)| {

--- a/db/src/sword_drill.rs
+++ b/db/src/sword_drill.rs
@@ -73,7 +73,7 @@ impl SwordDrillable for SwordDrill {
                     .into_boxed();
 
                 if let Some(ref verses) = reference.verses {
-                    query = query.filter(plain_text::verse.between(verses.start, verses.end));
+                    query = query.filter(plain_text::verse.between(verses.start(), verses.end()));
                 }
                 query.load(conn)
             }
@@ -85,12 +85,12 @@ impl SwordDrillable for SwordDrill {
                     .into_boxed();
 
                 if let Some(ref verses) = reference.verses {
-                    query = query.filter(html::verse.between(verses.start, verses.end));
+                    query = query.filter(html::verse.between(verses.start(), verses.end()));
                 }
                 query.load(conn)
             }
         }
-        .and_then(|verses| Ok((book, verses)))
+        .map(|verses| (book, verses))
         .map_err(|e| DbError::Other { cause: e })
     }
 

--- a/web/dist/js/main.js
+++ b/web/dist/js/main.js
@@ -1,3 +1,4 @@
+// Search box
 (function () {
     function getResults(q, cb) {
         if (!q) {
@@ -20,7 +21,7 @@
                     return "<p><i>" + result.link.label + "</i> | " + result.text + "</p>";
                 }
             }
-        },
+        }
     ]).on("autocomplete:selected", function (e, suggestion) {
         document.location.href = suggestion.link.url;
     });
@@ -41,6 +42,67 @@
         e.preventDefault();
         return false;
     };
-
-    navigator.serviceWorker && navigator.serviceWorker.register("/static/js/sw.js", { scope: "/" });
 })();
+
+// Swipe navigation
+(function () {
+    function detectSwipe(el, callback) {
+        var touchSurface = el;
+        var swipeDir;
+        var startX;
+        var startY;
+        var distX;
+        var distY;
+        var threshold = 50;
+        var restraint = 50;
+        var allowedTime = 300;
+        var elapsedTime;
+        var startTime;
+        var handleSwipe = callback || function () {};
+
+        touchSurface.addEventListener("touchstart", function (e) {
+            var touchObj = e.changedTouches[0];
+            swipeDir = "none";
+            distX = 0;
+            distY = 0;
+            startX = touchObj.pageX;
+            startY = touchObj.pageY;
+            startTime = new Date().getTime();
+        }, false);
+
+        touchSurface.addEventListener("touchend", function (e) {
+            var touchObj = e.changedTouches[0];
+            distX = touchObj.pageX - startX;
+            distY = touchObj.pageY - startY;
+            elapsedTime = new Date().getTime() - startTime;
+
+            if (elapsedTime <= allowedTime) {
+                if (Math.abs(distX) >= threshold && Math.abs(distY) <= restraint) {
+                    swipeDir = (distX < 0)? "left" : "right";
+                }
+                else if (Math.abs(distY) >= threshold && Math.abs(distX) <= restraint) {
+                    swipeDir = (distY < 0)? "up" : "down";
+                }
+            }
+            handleSwipe(swipeDir);
+        }, false);
+    }
+
+    var el = document.getElementsByTagName("main")[0];
+    var prevEl = document.getElementById("link-prev");
+    var nextEl = document.getElementById("link-next");
+    if (prevEl || nextEl) {
+        detectSwipe(el, function (swipeDir) {
+            if (swipeDir == "right" && prevEl) {
+                window.location.href = prevEl.getAttribute("href");
+            } else if (swipeDir == "left" && nextEl) {
+                window.location.href = nextEl.getAttribute("href");
+            }
+        });
+    }
+})();
+
+// Service worker registration
+if (navigator.serviceWorker) {
+    navigator.serviceWorker.register("/static/js/sw.js", { scope: "/" });
+}

--- a/web/dist/js/sw.js
+++ b/web/dist/js/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "biblers-cache-v4";
+const CACHE_NAME = "biblers-cache-v5";
 
 // Use cache before fetching from the network.
 self.addEventListener("fetch", (e) => {

--- a/web/src/responder/data.rs
+++ b/web/src/responder/data.rs
@@ -59,7 +59,7 @@ impl VersesData {
         reference.verses = if let Some(vs) = reference.verses {
             match verses.len() {
                 0 => None,
-                n => Some(vs.start..verses[n - 1].verse),
+                n => Some(*vs.start()..=verses[n - 1].verse),
             }
         } else {
             None

--- a/web/src/responder/link.rs
+++ b/web/src/responder/link.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 use actix_web::error::UrlGenerationError;
 use actix_web::HttpRequest;
@@ -122,12 +122,12 @@ pub(super) fn verse_url(b: &str, c: i32, v: i32, req: &HttpRequest) -> Link {
 }
 
 /// Generates a URL for verses from the given book, chapter, and verse range.
-fn verse_range_url(b: &str, c: i32, verses: &Range<i32>, req: &HttpRequest) -> Link {
+fn verse_range_url(b: &str, c: i32, verses: &RangeInclusive<i32>, req: &HttpRequest) -> Link {
     let chapter_string = c.to_string();
-    let verses_string = if verses.start == verses.end {
-        verses.start.to_string()
+    let verses_string = if verses.start() == verses.end() {
+        verses.start().to_string()
     } else {
-        format!("{}-{}", verses.start, verses.end)
+        format!("{}-{}", verses.start(), verses.end())
     };
     Link::new(
         &req.url_for(

--- a/web/templates/base.hbs
+++ b/web/templates/base.hbs
@@ -7,6 +7,12 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{meta.title}}</title>
     <link rel="canonical" href="{{meta.url}}">
+    {{~ #if data.links.previous}}
+    <link rel="prev" href="{{data.links.previous.url}}" id="link-prev">
+    {{~ /if}}
+    {{~ #if data.links.next}}
+    <link rel="next" href="{{data.links.next.url}}" id="link-next">
+    {{~ /if}}
     <link rel="shortcut icon" href="/static/img/bible.rs-32x32.png" type="image/png">
     <link rel="stylesheet" href="/static/css/style.css" media="all">
     <link rel="manifest" href="/static/manifest.json">


### PR DESCRIPTION
Swipe navigation is provided by a simple touch event handler that uses
`link` elements that may be in the `head` of the document. If the
`rel="prev"` and `rel="next"` elements exist, then they are used to
allow for gesture navigation by swiping left and right on a
touch-enabled device.

Also invalidate the PWA asset cache so the newer version of the JS is
delivered.