### PR TITLE
Fix API verse format

### DIFF
--- a/web/src/controllers/api.rs
+++ b/web/src/controllers/api.rs
@@ -79,6 +79,7 @@ mod tests {
             result.matches[0].text,
             "NUN. Thy word is a lamp unto my feet, and a <em>light</em> unto my path."
         );
+        assert_eq!(result.matches[0].link.url, "/Psalms/119#v105");
 
         // By reference
         let result: SearchResultData = json_response("/api/search?q=psalms%20119:105");
@@ -86,5 +87,6 @@ mod tests {
             result.matches[0].text,
             "NUN. Thy word is a lamp unto my feet, and a light unto my path."
         );
+        assert_eq!(result.matches[0].link.url, "/Psalms/119#v105");
     }
 }

--- a/web/src/responder/data.rs
+++ b/web/src/responder/data.rs
@@ -114,7 +114,7 @@ impl AllBooksData {
 /// A search result.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct SearchResult {
-    link: Link,
+    pub link: Link,
     pub text: String,
 }
 

--- a/web/src/responder/link.rs
+++ b/web/src/responder/link.rs
@@ -111,14 +111,11 @@ fn chapter_url(b: &str, c: i32, req: &HttpRequest) -> Link {
 pub(super) fn verse_url(b: &str, c: i32, v: i32, req: &HttpRequest) -> Link {
     let chapter_string = c.to_string();
     let verse_string = v.to_string();
-    Link::new(
-        &req.url_for(
-            "reference",
-            &[format!("{}/{}#v{}", b, chapter_string, verse_string)],
-        )
-        .unwrap_or_else(invalid_url),
-        format!("{} {}:{}", b, chapter_string, verse_string),
-    )
+    let mut url = req
+        .url_for("reference", &[format!("{}/{}", b, chapter_string)])
+        .unwrap_or_else(invalid_url);
+    url.set_fragment(Some(&format!("v{}", verse_string)));
+    Link::new(&url, format!("{} {}:{}", b, chapter_string, verse_string))
 }
 
 /// Generates a URL for verses from the given book, chapter, and verse range.

--- a/web/src/test.rs
+++ b/web/src/test.rs
@@ -56,7 +56,7 @@ impl SwordDrillable for TestSwordDrill {
         let verse = Verse {
             id: 555,
             book: 19,
-            chapter: 1,
+            chapter: 119,
             verse: 105,
             words: "NUN. Thy word is a lamp unto my feet, and a light unto my path.".to_string(),
         };
@@ -76,7 +76,7 @@ impl SwordDrillable for TestSwordDrill {
         let book = test_book();
         let verse = VerseFTS {
             book: 19,
-            chapter: 1,
+            chapter: 119,
             verse: 105,
             words: "NUN. Thy word is a lamp unto my feet, and a <em>light</em> unto my path."
                 .to_string(),


### PR DESCRIPTION
In actix-web v4, the URL fragment was being URL encoded. This commit
sets the fragment properly and adds a test to catch the problem.